### PR TITLE
Adding provider source explicitly

### DIFF
--- a/extensions/mongodbatlas/terraform/mongodbatlas_main.tf
+++ b/extensions/mongodbatlas/terraform/mongodbatlas_main.tf
@@ -160,3 +160,11 @@ resource "null_resource" "vm_provisioners_atlas_realm_app" {
     }
   }
 }
+
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+    }
+  }
+}


### PR DESCRIPTION
This is now required by Terraform for external providers:
https://www.terraform.io/upgrade-guides/0-13.html#explicit-provider-source-locations