### PR TITLE
Adding tags for provisioning workshop in AWS

### DIFF
--- a/core/terraform/aws/main.tf
+++ b/core/terraform/aws/main.tf
@@ -2,6 +2,13 @@ provider "aws" {
   region     = var.region
   access_key = var.access_key
   secret_key = var.secret_key
+  default_tags {
+      tags = {
+          owner_email = var.owner_email
+          purpose = var.purpose
+          ref_link = var.ref_link
+      }
+  }
 }
 
 module "workshop-core" {

--- a/core/terraform/aws/variables.tf
+++ b/core/terraform/aws/variables.tf
@@ -64,3 +64,15 @@ variable "feedback_form_url" {
   description = "Feedback Form Url"
   default = ""
 }
+
+variable "owner_email" {
+  description = "Workshop owner email tag"
+}
+
+variable "purpose" {
+  description = "Workshop purpose tag"
+}
+
+variable "ref_link" {
+  description = "Workshop github repo tag"
+}

--- a/workshop-example-aws.yaml
+++ b/workshop-example-aws.yaml
@@ -40,6 +40,11 @@ workshop:
     #Feedback Form url (Optional)
     #feedback_form_url: "<Feedback Form Url>"
 
+    #tags
+    owner_email: <Your email>
+    purpose: <Workshop name>
+    ref_link: <Workshop Git repo url>
+
   #
   # workshop extensions
   #


### PR DESCRIPTION
Adding tags  (owner_email ,purpose  and ref_link) for AWS workshop deployment in main.tf , required variables in variables.tf  and modify yaml file.   
