### PR TITLE
Adding confluent terraform provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ Each workshop participant will work through a series of Labs to create the follo
 * Terraform 0.12.20 or later
 * Python + [Yaml](https://pyyaml.org/wiki/PyYAML)
 * A GCP/AWS/Azure account with the appropriate privileges
+* For setting AWS credentials, please check the following link: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where
 * A Confluent Cloud Account
 * [MongoDB Realm CLI](https://docs.mongodb.com/realm/deploy/realm-cli-reference/#installation) (required if you use the MongoDB Atlas extension)
+
+## Things to know before starting
+
+This repository is going to create the required  Confluent Cloud features (Environment, Cluster, API keys...).
+The cluster type by default is Basic. If it is necessary to use Standard or Dedicated cluster, please check this link to make the required changes:
+https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_kafka_cluster .
 
 ## Provisioning a Workshop
 
@@ -49,6 +56,13 @@ To start provisioning the workshop, run `workshop-create.py` and pass in your wo
 
 ```
 python3 workshop-create.py --dir ~/myworkshop
+```
+Maybe you will need to execute the following commands before executing the previous script:
+```
+python3 -m pip install boto3
+python3 -m pip install google
+python3 -m pip install google-api-python-client
+python3 -m pip install azure-cli
 ```
 
 When you are finished with the workshop you can destroy it using `workshop-destroy.py`

--- a/core/docker/docker-compose.yaml
+++ b/core/docker/docker-compose.yaml
@@ -352,19 +352,19 @@ services:
     volumes:
       - ./asciidoc:/usr/share/nginx/html
  
-  create-cloud-topics:
-    image: confluentinc/cp-kafka:${CONFLUENT_DOCKER_TAG}
-    hostname: create-cloud-topics
-    container_name: create-cloud-topics
-    volumes:
-      - ./ccloud.properties:/ccloud.properties
-      - ./util_functions.sh:/util_functions.sh
-    command: "bash -c 'source /util_functions.sh; create_ccloud_topics ${CCLOUD_TOPICS} ${DC}'"
-    environment:
+#  create-cloud-topics:
+#    image: confluentinc/cp-kafka:${CONFLUENT_DOCKER_TAG}
+#    hostname: create-cloud-topics
+#    container_name: create-cloud-topics
+#    volumes:
+#      - ./ccloud.properties:/ccloud.properties
+#      - ./util_functions.sh:/util_functions.sh
+#    command: "bash -c 'source /util_functions.sh; create_ccloud_topics ${CCLOUD_TOPICS} ${DC}'"
+#    environment:
       # The following settings are listed here only to satisfy the image’s requirements.
       # We override the image’s command anyways, hence this container will not start a broker.
-      KAFKA_BROKER_ID: ignored
-      KAFKA_ZOOKEEPER_CONNECT: ignored
+#      KAFKA_BROKER_ID: ignored
+#      KAFKA_ZOOKEEPER_CONNECT: ignored
 
   create-onprem-topics:
     image: confluentinc/cp-kafka:${CONFLUENT_DOCKER_TAG}

--- a/core/terraform/aws/main.tf
+++ b/core/terraform/aws/main.tf
@@ -6,9 +6,9 @@ provider "aws" {
   default_tags {
       tags = {
           owner_email = var.owner_email
-          purpose = var.purpose
-          ref_link = var.ref_link
-          Deployed_By: "Terraform"
+          purpose     = var.purpose
+          ref_link    = var.ref_link
+          deployed_By = "Terraform"
       }
   }
 }
@@ -22,10 +22,29 @@ module "workshop-core" {
   vm_type                  = var.vm_type
   vm_disk_size             = var.vm_disk_size
   ami                      = var.ami
-  ccloud_bootstrap_servers = var.ccloud_bootstrap_servers
-  ccloud_api_key           = var.ccloud_api_key
-  ccloud_api_secret        = var.ccloud_api_secret
-  ccloud_topics            = var.ccloud_topics
+  ccloud_bootstrap_servers = module.workshop-confluent-core.boostrap
+  ccloud_api_key           = module.workshop-confluent-core.cluster_api_key
+  ccloud_api_secret        = module.workshop-confluent-core.cluster_api_secret
+#  ccloud_topics            = var.ccloud_topics
   onprem_topics            = var.onprem_topics
   feedback_form_url        = var.feedback_form_url
+  availability_zones       = var.availability_zones
+}
+
+
+
+
+module "workshop-confluent-core" {
+  source                   = "././common/confluent-cloud"
+  ccloud_api_key           = var.ccloud_api_key
+  ccloud_api_secret        = var.ccloud_api_secret
+  ccloud_cluster_name      = var.ccloud_cluster_name
+  region                   = var.region
+  participant_count        = var.participant_count
+  ccloud_topics            = var.ccloud_topics
+  ccloud_sr_region         = var.ccloud_sr_region
+  ccloud_package_sg        = var.ccloud_package_sg
+  cloud_provider           = var.cloud_provider
+  ccloud_cluster_availability_type = var.ccloud_cluster_availability_type
+  name                      = var.name
 }

--- a/core/terraform/aws/outputs.tf
+++ b/core/terraform/aws/outputs.tf
@@ -6,8 +6,8 @@ output "security_group_id" {
   value = module.workshop-core.security_group_id
 }
 
-output "subnet_group_id" {
-  value = module.workshop-core.subnet_group_id
+output "subnet" {
+  value = module.workshop-core.subnet
 }
 
 output "topic" {

--- a/core/terraform/aws/outputs.tf
+++ b/core/terraform/aws/outputs.tf
@@ -5,3 +5,11 @@ output "external_ip_addresses" {
 output "security_group_id" {
   value = module.workshop-core.security_group_id
 }
+
+output "subnet_group_id" {
+  value = module.workshop-core.subnet_group_id
+}
+
+output "topic" {
+  value = module.workshop-confluent-core.topics
+}

--- a/core/terraform/aws/variables.tf
+++ b/core/terraform/aws/variables.tf
@@ -40,9 +40,9 @@ variable "ami" {
 #}
 
 // Confluent Cloud variables
-variable "ccloud_bootstrap_servers" {
-  description = "Confluent Cloud username"
-}
+#variable "ccloud_bootstrap_servers" {
+#  description = "Confluent Cloud username"
+#}
 
 variable "ccloud_api_key" {
   description = "Confluent Cloud password"
@@ -74,7 +74,6 @@ variable "purpose" {
 }
 
 variable "availability_zones" {
-  default     = ["eu-west-2a", "eu-west-2b"]
   type        = list
   description = "List of availability zones"
 }
@@ -86,4 +85,31 @@ variable "ref_link" {
 
 variable "owner_email" {
    description = "Confluent owners email address for resource tagging"
+}
+
+variable "ccloud_env_name" {
+   description = "Confluent cloud environment name"
+}
+
+variable "ccloud_cluster_name" {
+   description = "Confluent cloud cluster name"
+}
+
+variable "ccloud_cluster_availability_type" {
+   description = "Confluent cloud cluster type availability_type"
+   default = "SINGLE_ZONE"
+}
+
+variable "ccloud_sr_region" {
+  description = "Schema registry region"
+  default = "eu-central-1"
+}
+
+variable "ccloud_package_sg" {
+  description = "Stream Governance package type"
+  default = "ESSENTIALS"
+}
+
+variable "cloud_provider" {
+  description = "Cloud provider"
 }

--- a/core/terraform/aws/workshop-core/main.tf
+++ b/core/terraform/aws/workshop-core/main.tf
@@ -90,12 +90,6 @@ resource "aws_subnet" "workshop-public-subnet" {
   map_public_ip_on_launch = true
 }
 
-resource "aws_redshift_subnet_group" "workshop-public-subnet-group" {
-  name       = "workshop-public-subnet-group"
-  subnet_ids = aws_subnet.workshop-public-subnet.*.id
-
-}
-
 resource "aws_route_table" "workshop-public-route-table" {
   vpc_id = aws_vpc.workshop-vpc.id
 }

--- a/core/terraform/aws/workshop-core/main.tf
+++ b/core/terraform/aws/workshop-core/main.tf
@@ -22,7 +22,7 @@ data "template_file" "bootstrap_docker" {
     ccloud_cluster_endpoint = var.ccloud_bootstrap_servers
     ccloud_api_key          = var.ccloud_api_key
     ccloud_api_secret       = var.ccloud_api_secret
-    ccloud_topics           = var.ccloud_topics
+#    ccloud_topics           = var.ccloud_topics
     onprem_topics           = var.onprem_topics
     feedback_form_url       = var.feedback_form_url
     cloud_provider          = "aws"
@@ -88,6 +88,12 @@ resource "aws_subnet" "workshop-public-subnet" {
   cidr_block              = var.public_subnet_cidr_blocks[count.index]
   availability_zone       = var.availability_zones[count.index]
   map_public_ip_on_launch = true
+}
+
+resource "aws_redshift_subnet_group" "workshop-public-subnet-group" {
+  name       = "workshop-public-subnet-group"
+  subnet_ids = aws_subnet.workshop-public-subnet.*.id
+
 }
 
 resource "aws_route_table" "workshop-public-route-table" {

--- a/core/terraform/aws/workshop-core/outputs.tf
+++ b/core/terraform/aws/workshop-core/outputs.tf
@@ -6,8 +6,8 @@ output "security_group_id" {
   value = aws_security_group.instance.id
 }
 
-output "subnet_group_id" {
-  value = aws_redshift_subnet_group.workshop-public-subnet-group.id
+output "subnet" {
+  value = aws_subnet.workshop-public-subnet.*.id
 }
 
 output "ws_iam_user_name" {

--- a/core/terraform/aws/workshop-core/outputs.tf
+++ b/core/terraform/aws/workshop-core/outputs.tf
@@ -6,6 +6,10 @@ output "security_group_id" {
   value = aws_security_group.instance.id
 }
 
+output "subnet_group_id" {
+  value = aws_redshift_subnet_group.workshop-public-subnet-group.id
+}
+
 output "ws_iam_user_name" {
   value = aws_iam_user.ws.name
 }

--- a/core/terraform/aws/workshop-core/variables.tf
+++ b/core/terraform/aws/workshop-core/variables.tf
@@ -42,9 +42,9 @@ variable "ccloud_api_secret" {
   description = "Confluent Cloud Provider"
 }
 
-variable "ccloud_topics" {
-  description = "Confluent Cloud topics to precreate"
-}
+#variable "ccloud_topics" {
+#  description = "Confluent Cloud topics to precreate"
+#}
 
 variable "onprem_topics" {
   description = "Confluent Server local on-prem to precreate"
@@ -65,7 +65,6 @@ variable "public_subnet_cidr_blocks" {
 }
 
 variable "availability_zones" {
-  default     = ["eu-west-2a", "eu-west-2b"]
   type        = list
   description = "List of availability zones"
 }

--- a/core/terraform/azure/main.tf
+++ b/core/terraform/azure/main.tf
@@ -1,5 +1,4 @@
 provider "azurerm" {
-  version         = "=2.0.0"
   subscription_id = var.subscription_id
   client_id       = var.client_id
   client_secret   = var.client_secret
@@ -8,7 +7,6 @@ provider "azurerm" {
 }
 
 provider "random" {
-  version = "~> 2.2"
 }
 
 module "workshop-core" {
@@ -19,11 +17,30 @@ module "workshop-core" {
   location                  = var.location
   vm_type                   = var.vm_type
   vm_disk_size              = var.vm_disk_size
-  ccloud_bootstrap_servers  = var.ccloud_bootstrap_servers
-  ccloud_api_key            = var.ccloud_api_key
-  ccloud_api_secret         = var.ccloud_api_secret
-  ccloud_topics             = var.ccloud_topics
+  ccloud_bootstrap_servers  = module.workshop-confluent-core.boostrap
+  ccloud_api_key           = module.workshop-confluent-core.cluster_api_key
+  ccloud_api_secret        = module.workshop-confluent-core.cluster_api_secret
+#  ccloud_topics             = var.ccloud_topics
   onprem_topics             = var.onprem_topics
   feedback_form_url         = var.feedback_form_url
+  owner_email               = var.owner_email
+  purpose                   = var.purpose
+  ref_link                  = var.ref_link
 }
 
+
+
+module "workshop-confluent-core" {
+  source                   = "././common/confluent-cloud"
+  ccloud_api_key           = var.ccloud_api_key
+  ccloud_api_secret        = var.ccloud_api_secret
+  ccloud_cluster_name      = var.ccloud_cluster_name
+  region                   = var.location
+  participant_count        = var.participant_count
+  ccloud_topics            = var.ccloud_topics
+  ccloud_sr_region         = var.ccloud_sr_region
+  ccloud_package_sg        = var.ccloud_package_sg
+  cloud_provider           = var.cloud_provider
+  ccloud_cluster_availability_type = var.ccloud_cluster_availability_type
+  name                      = var.name
+}

--- a/core/terraform/azure/outputs.tf
+++ b/core/terraform/azure/outputs.tf
@@ -1,3 +1,7 @@
 output "external_ip_addresses" {
   value = module.workshop-core.external_ip_addresses
 }
+
+output "topic" {
+  value = module.workshop-confluent-core.topics
+}

--- a/core/terraform/azure/variables.tf
+++ b/core/terraform/azure/variables.tf
@@ -42,9 +42,9 @@ variable "location" {
 }
 
 // Confluent Cloud variables
-variable "ccloud_bootstrap_servers" {
-  description = "Confluent Cloud username"
-}
+#variable "ccloud_bootstrap_servers" {
+#  description = "Confluent Cloud username"
+#}
 
 variable "ccloud_api_key" {
   description = "Confluent Cloud password"
@@ -65,4 +65,44 @@ variable "onprem_topics" {
 variable "feedback_form_url" {
   description = "Feedback Form Url"
   default = ""
+}
+
+variable "purpose" {
+  description = "Workshop purpose tag"
+}
+
+variable "ref_link" {
+  description = "Workshop github repo tag"
+  default = ""
+}
+
+variable "owner_email" {
+  description = "Confluent owners email address for resource tagging"
+}
+
+variable "ccloud_env_name" {
+  description = "Confluent cloud environment name"
+}
+
+variable "ccloud_cluster_name" {
+  description = "Confluent cloud cluster name"
+}
+
+variable "ccloud_cluster_availability_type" {
+  description = "Confluent cloud cluster type availability_type"
+  default = "SINGLE_ZONE"
+}
+
+variable "ccloud_sr_region" {
+  description = "Schema registry region"
+  default = "eu-central-1"
+}
+
+variable "ccloud_package_sg" {
+  description = "Stream Governance package type"
+  default = "ESSENTIALS"
+}
+
+variable "cloud_provider" {
+  description = "Cloud provider"
 }

--- a/core/terraform/azure/workshop-core/main.tf
+++ b/core/terraform/azure/workshop-core/main.tf
@@ -1,7 +1,11 @@
 
 locals {
   common_tags = {
-    project  = "workshop-framework"
+    project     = "workshop-framework"
+    owner_email = var.owner_email
+    purpose     = var.purpose
+    ref_link    = var.ref_link
+    deployed_By = "Terraform"
   }
   extra_tags  = {
     workshop-name = "${var.name}"
@@ -27,7 +31,7 @@ data "template_file" "bootstrap_docker" {
     ccloud_cluster_endpoint = var.ccloud_bootstrap_servers
     ccloud_api_key          = var.ccloud_api_key
     ccloud_api_secret       = var.ccloud_api_secret
-    ccloud_topics           = var.ccloud_topics
+#    ccloud_topics           = var.ccloud_topics
     onprem_topics           = var.onprem_topics
     feedback_form_url       = var.feedback_form_url
     cloud_provider          = "azure"
@@ -55,7 +59,7 @@ resource "azurerm_subnet" "instance" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.instance.name
   virtual_network_name = azurerm_virtual_network.instance.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "instance" {

--- a/core/terraform/azure/workshop-core/variables.tf
+++ b/core/terraform/azure/workshop-core/variables.tf
@@ -38,9 +38,9 @@ variable "ccloud_api_secret" {
   description = "Confluent Cloud Provider"
 }
 
-variable "ccloud_topics" {
-  description = "Confluent Cloud topics to precreate"
-}
+#variable "ccloud_topics" {
+#  description = "Confluent Cloud topics to precreate"
+#}
 
 variable "onprem_topics" {
   description = "Confluent Server on-prem topics to precreate"
@@ -48,4 +48,17 @@ variable "onprem_topics" {
 
 variable "feedback_form_url" {
   description = "Feedback Form Url"
+}
+
+variable "purpose" {
+  description = "Workshop purpose tag"
+}
+
+variable "ref_link" {
+  description = "Workshop github repo tag"
+  default = ""
+}
+
+variable "owner_email" {
+  description = "Confluent owners email address for resource tagging"
 }

--- a/core/terraform/common/bootstrap_docker.tpl
+++ b/core/terraform/common/bootstrap_docker.tpl
@@ -17,7 +17,6 @@ echo "CCLOUD_API_KEY=${ccloud_api_key}" >> .env
 echo "CCLOUD_API_SECRET=${ccloud_api_secret}" >> .env
 echo "HOSTNAME"=$HOSTNAME >> .env
 echo "DC"=${dc} >> .env
-echo "CCLOUD_TOPICS"=${ccloud_topics} >> .env
 echo "ONPREM_TOPICS"=${onprem_topics} >> .env
 echo "CONFLUENT_DOCKER_TAG"=7.3.0 >> .env
 

--- a/core/terraform/common/bootstrap_vm.tpl
+++ b/core/terraform/common/bootstrap_vm.tpl
@@ -14,7 +14,7 @@ sudo apt-get install \
     software-properties-common -y
 
 echo "--- Installing Docker ---"
-curl -L https://download.docker.com/linux/static/stable/x86_64/docker-19.03.4.tgz -o docker.tgz
+curl -L https://download.docker.com/linux/static/stable/x86_64/docker-20.10.9.tgz -o docker.tgz
 sudo tar xvf docker.tgz -C /usr/bin --wildcards 'docker/*' --strip 1
 rm docker.tgz
 sudo groupadd docker

--- a/core/terraform/common/confluent-cloud/main.tf
+++ b/core/terraform/common/confluent-cloud/main.tf
@@ -1,0 +1,138 @@
+terraform {
+  required_providers {
+    confluent = {
+      source  = "confluentinc/confluent"
+      #version = "1.24.0"
+    }
+  }
+}
+
+data "confluent_schema_registry_region" "sr_region" {
+  cloud   = upper(var.cloud_provider)
+  region  = var.ccloud_sr_region
+  package = var.ccloud_package_sg
+}
+
+provider "confluent" {
+  # Configuration options
+  cloud_api_key    = var.ccloud_api_key
+  cloud_api_secret = var.ccloud_api_secret
+
+}
+
+resource "confluent_environment" "hybrid-workshop" {
+  display_name = "${var.name}-${var.ccloud_cluster_name}"
+
+}
+
+resource "confluent_kafka_cluster" "hybrid-cluster" {
+  display_name = "${var.name}-${var.ccloud_cluster_name}"
+  availability = var.ccloud_cluster_availability_type
+  cloud        = upper(var.cloud_provider)
+  region       = var.region
+  basic {}
+
+  environment {
+    id = confluent_environment.hybrid-workshop.id
+  }
+
+}
+
+resource "confluent_schema_registry_cluster" "essentials" {
+  package = data.confluent_schema_registry_region.sr_region.package
+
+  environment {
+    id = confluent_environment.hybrid-workshop.id
+  }
+
+  region {
+    id = data.confluent_schema_registry_region.sr_region.id
+  }
+}
+
+resource "confluent_service_account" "hybrid-manager" {
+  display_name = "${var.name}-hybrid-manager"
+  description  = "Service Account for hybrid workshop"
+}
+
+resource "confluent_role_binding" "hybrid-manager-kafka-cluster-admin" {
+  principal   = "User:${confluent_service_account.hybrid-manager.id}"
+  role_name   = "CloudClusterAdmin"
+  crn_pattern = confluent_kafka_cluster.hybrid-cluster.rbac_crn
+}
+
+resource "confluent_api_key" "hybrid-manager-kafka-api-key" {
+  display_name = "${var.name}-hybrid-manager-kafka-api-key"
+  description  = "Kafka API Key that is owned by 'sa-hybrid-service_account' service account"
+  owner {
+    id          = confluent_service_account.hybrid-manager.id
+    api_version = confluent_service_account.hybrid-manager.api_version
+    kind        = confluent_service_account.hybrid-manager.kind
+  }
+
+  managed_resource {
+    id          = confluent_kafka_cluster.hybrid-cluster.id
+    api_version = confluent_kafka_cluster.hybrid-cluster.api_version
+    kind        = confluent_kafka_cluster.hybrid-cluster.kind
+
+    environment {
+      id = confluent_environment.hybrid-workshop.id
+
+    }
+  }
+    depends_on = [
+      confluent_role_binding.hybrid-manager-kafka-cluster-admin
+    ]
+}
+
+
+resource "confluent_kafka_topic" "topic" {
+  count           = length(local.product)
+
+  kafka_cluster {
+    id = confluent_kafka_cluster.hybrid-cluster.id
+  }
+  topic_name = format("dc%02d_%s",element(local.product, count.index)[0],element(local.product, count.index)[1])
+  partitions_count   = 1
+  rest_endpoint      = confluent_kafka_cluster.hybrid-cluster.rest_endpoint
+  credentials {
+    key    = confluent_api_key.hybrid-manager-kafka-api-key.id
+    secret = confluent_api_key.hybrid-manager-kafka-api-key.secret
+  }
+}
+
+resource "confluent_kafka_acl" "hybrid-manager-write-on-topic" {
+  kafka_cluster {
+    id = confluent_kafka_cluster.hybrid-cluster.id
+  }
+  resource_type = "TOPIC"
+  resource_name = "dc_"
+  pattern_type  = "PREFIXED"
+  principal     = "User:${confluent_service_account.hybrid-manager.id}"
+  host          = "*"
+  operation     = "WRITE"
+  permission    = "ALLOW"
+  rest_endpoint = confluent_kafka_cluster.hybrid-cluster.rest_endpoint
+  credentials {
+    key    = confluent_api_key.hybrid-manager-kafka-api-key.id
+    secret = confluent_api_key.hybrid-manager-kafka-api-key.secret
+  }
+}
+
+resource "confluent_kafka_acl" "hybrid-manager-delete-topic" {
+  kafka_cluster {
+    id = confluent_kafka_cluster.hybrid-cluster.id
+  }
+  resource_type = "TOPIC"
+  resource_name = "dc_"
+  pattern_type  = "PREFIXED"
+  principal     = "User:${confluent_service_account.hybrid-manager.id}"
+  host          = "*"
+  operation     = "DELETE"
+  permission    = "ALLOW"
+  rest_endpoint = confluent_kafka_cluster.hybrid-cluster.rest_endpoint
+  credentials {
+    key    = confluent_api_key.hybrid-manager-kafka-api-key.id
+    secret = confluent_api_key.hybrid-manager-kafka-api-key.secret
+  }
+}

--- a/core/terraform/common/confluent-cloud/outputs.tf
+++ b/core/terraform/common/confluent-cloud/outputs.tf
@@ -1,0 +1,15 @@
+output "topics" {
+  value =local.product
+}
+
+output "boostrap" {
+  value =confluent_kafka_cluster.hybrid-cluster.bootstrap_endpoint
+}
+
+output "cluster_api_key" {
+  value = confluent_api_key.hybrid-manager-kafka-api-key.id
+}
+
+output "cluster_api_secret" {
+  value = confluent_api_key.hybrid-manager-kafka-api-key.secret
+}

--- a/core/terraform/common/confluent-cloud/variables.tf
+++ b/core/terraform/common/confluent-cloud/variables.tf
@@ -1,0 +1,54 @@
+// Workshop variables
+variable "ccloud_api_key" {
+  description = "Confluent Cloud password"
+}
+
+variable "ccloud_api_secret" {
+  description = "Confluent Cloud Provider"
+}
+
+variable "ccloud_cluster_name" {
+  description = "Confluent cloud cluster name"
+}
+variable "region" {
+  default = "us-central1"
+}
+
+variable "ccloud_cluster_availability_type" {
+  description = "Confluent cloud cluster type availability_type"
+  default = "SINGLE_ZONE"
+}
+
+variable "ccloud_topics" {
+  description = "Confluent Cloud topics to precreate"
+  default =""
+}
+
+variable "participant_count" {
+  description = "How number of participants attending the workshop"
+  type        = number
+  default     = 1
+}
+
+variable "ccloud_sr_region" {
+  description = "Schema registry region"
+  default = "eu-central-1"
+}
+
+variable "ccloud_package_sg" {
+  description = "Stream Governance package type"
+  default = "ESSENTIALS"
+}
+
+
+variable "cloud_provider" {
+  description = "Cloud provider"
+}
+
+variable "name" {
+  description = "The Prefix used for all resources in this example"
+}
+
+locals {
+  product = setproduct(range(1,var.participant_count+1,1), split(",",var.ccloud_topics))
+}

--- a/core/terraform/gcp/main.tf
+++ b/core/terraform/gcp/main.tf
@@ -18,10 +18,28 @@ module "workshop-core" {
   credentials_file_path    = var.credentials_file_path
   vm_type                  = var.vm_type
   vm_disk_size             = var.vm_disk_size
-  ccloud_bootstrap_servers = var.ccloud_bootstrap_servers
-  ccloud_api_key           = var.ccloud_api_key
-  ccloud_api_secret        = var.ccloud_api_secret
-  ccloud_topics            = var.ccloud_topics
+  ccloud_bootstrap_servers = module.workshop-confluent-core.boostrap
+  ccloud_api_key           = module.workshop-confluent-core.cluster_api_key
+  ccloud_api_secret        = module.workshop-confluent-core.cluster_api_secret
+#  ccloud_topics            = var.ccloud_topics
   onprem_topics            = var.onprem_topics
   feedback_form_url        = var.feedback_form_url
+  owner_email              = var.owner_email
+  purpose                  = var.purpose
+  ref_link                 = var.ref_link
+}
+
+module "workshop-confluent-core" {
+  source                   = "././common/confluent-cloud"
+  ccloud_api_key           = var.ccloud_api_key
+  ccloud_api_secret        = var.ccloud_api_secret
+  ccloud_cluster_name      = var.ccloud_cluster_name
+  region                   = var.region
+  participant_count        = var.participant_count
+  ccloud_topics            = var.ccloud_topics
+  ccloud_sr_region         = var.ccloud_sr_region
+  ccloud_package_sg        = var.ccloud_package_sg
+  cloud_provider           = var.cloud_provider
+  ccloud_cluster_availability_type = var.ccloud_cluster_availability_type
+  name                      = var.name
 }

--- a/core/terraform/gcp/outputs.tf
+++ b/core/terraform/gcp/outputs.tf
@@ -1,4 +1,7 @@
 output "external_ip_addresses" {
   value = module.workshop-core.external_ip_addresses
 }
+output "topic" {
+  value = module.workshop-confluent-core.topics
+}
 

--- a/core/terraform/gcp/variables.tf
+++ b/core/terraform/gcp/variables.tf
@@ -40,9 +40,9 @@ variable "vm_disk_size" {
 }
 
 // Confluent Cloud variables
-variable "ccloud_bootstrap_servers" {
-  description = "Confluent Cloud username"
-}
+#variable "ccloud_bootstrap_servers" {
+#  description = "Confluent Cloud username"
+#}
 
 variable "ccloud_api_key" {
   description = "Confluent Cloud password"
@@ -63,4 +63,44 @@ variable "onprem_topics" {
 variable "feedback_form_url" {
   description = "Feedback Form Url"
   default = ""
+}
+
+variable "purpose" {
+  description = "Workshop purpose tag"
+}
+
+variable "ref_link" {
+  description = "Workshop github repo tag"
+  default = ""
+}
+
+variable "owner_email" {
+  description = "Confluent owners email address for resource tagging"
+}
+
+variable "ccloud_env_name" {
+  description = "Confluent cloud environment name"
+}
+
+variable "ccloud_cluster_name" {
+  description = "Confluent cloud cluster name"
+}
+
+variable "ccloud_cluster_availability_type" {
+  description = "Confluent cloud cluster type availability_type"
+  default = "SINGLE_ZONE"
+}
+
+variable "ccloud_sr_region" {
+  description = "Schema registry region"
+  default = "eu-central-1"
+}
+
+variable "ccloud_package_sg" {
+  description = "Stream Governance package type"
+  default = "ESSENTIALS"
+}
+
+variable "cloud_provider" {
+  description = "Cloud provider"
 }

--- a/core/terraform/gcp/workshop-core/main.tf
+++ b/core/terraform/gcp/workshop-core/main.tf
@@ -23,13 +23,14 @@ data "template_file" "bootstrap_docker" {
     ccloud_cluster_endpoint = var.ccloud_bootstrap_servers
     ccloud_api_key          = var.ccloud_api_key
     ccloud_api_secret       = var.ccloud_api_secret
-    ccloud_topics           = var.ccloud_topics
+#    ccloud_topics           = var.ccloud_topics
     onprem_topics           = var.onprem_topics
     feedback_form_url       = var.feedback_form_url
     cloud_provider          = "gcp"
   }
 }
-
+data "google_project" "project" {
+}
 /*
  Resources
 */
@@ -47,6 +48,7 @@ resource "google_compute_firewall" "workshop-firewall" {
     protocol = "tcp"
     ports    = ["22", "9021", "80", "8088", "8089","18088"]
   }
+  source_ranges = ["0.0.0.0/0"]
 }
 
 resource "google_compute_address" "instance" {
@@ -96,6 +98,7 @@ SCRIPT
       password = var.participant_password
       insecure = true
       host     = element(google_compute_address.instance.*.address, count.index)
+      type     = "ssh"
     }
   }
 
@@ -111,6 +114,7 @@ SCRIPT
       password = var.participant_password
       insecure = true
       host     = element(google_compute_address.instance.*.address, count.index)
+      type     = "ssh"
     }
   }
 

--- a/core/terraform/gcp/workshop-core/variables.tf
+++ b/core/terraform/gcp/workshop-core/variables.tf
@@ -50,9 +50,9 @@ variable "ccloud_api_secret" {
   description = "Confluent Cloud Provider"
 }
 
-variable "ccloud_topics" {
-  description = "Confluent Cloud topics to precreate"
-}
+#variable "ccloud_topics" {
+#  description = "Confluent Cloud topics to precreate"
+#}
 
 variable "onprem_topics" {
   description = "Confluent Server on-prem topics to precreate"
@@ -60,4 +60,17 @@ variable "onprem_topics" {
 
 variable "feedback_form_url" {
   description = "Feedback Form Url"
+}
+
+variable "purpose" {
+  description = "Workshop purpose tag"
+}
+
+variable "ref_link" {
+  description = "Workshop github repo tag"
+  default = ""
+}
+
+variable "owner_email" {
+  description = "Confluent owners email address for resource tagging"
 }

--- a/extensions/aws-dynamodb/terraform/aws_dynamodb_main.tf
+++ b/extensions/aws-dynamodb/terraform/aws_dynamodb_main.tf
@@ -4,7 +4,7 @@ resource "random_string" "dynamodb_random_string" {
   special = false
   upper = false
   lower = true
-  number = false
+  numeric = false
 }
 
 data "template_file" "dynamodb_table_name" {
@@ -91,7 +91,7 @@ resource "null_resource" "dynamodb_provisioners" {
 
   provisioner "remote-exec" {
     inline = [
-      "cat /tmp/dynamodb_conn_info.txt >> ~/.workshop/docker/.env",
+      "cat /tmp/dynamodb_conn_info.txt >> .workshop/docker/.env",
       "rm /tmp/dynamodb_conn_info.txt"
     ]
 

--- a/extensions/aws-redshift/terraform/aws_redshift_main.tf
+++ b/extensions/aws-redshift/terraform/aws_redshift_main.tf
@@ -9,6 +9,7 @@ resource "aws_redshift_cluster" "instance" {
   number_of_nodes     = 1
   skip_final_snapshot = true
   publicly_accessible = false
+  cluster_subnet_group_name = module.workshop-core.subnet_group_id
   vpc_security_group_ids = [module.workshop-core.security_group_id]
 }
 
@@ -40,7 +41,7 @@ resource "null_resource" "redshift_provisioners" {
 
   provisioner "remote-exec" {
     inline = [
-      "cat /tmp/rs_jdbc_url.txt >> ~/.workshop/docker/.env",
+      "cat /tmp/rs_jdbc_url.txt >> .workshop/docker/.env",
       "rm /tmp/rs_jdbc_url.txt"
     ]
 

--- a/extensions/aws-redshift/terraform/aws_redshift_main.tf
+++ b/extensions/aws-redshift/terraform/aws_redshift_main.tf
@@ -1,3 +1,9 @@
+resource "aws_redshift_subnet_group" "workshop-public-subnet-group" {
+  name       = "workshop-public-subnet-group"
+  subnet_ids = module.workshop-core.subnet
+
+}
+
 resource "aws_redshift_cluster" "instance" {
   cluster_identifier  = "${var.name}-rs-cluster"
   database_name       = "${var.name}db"
@@ -9,7 +15,7 @@ resource "aws_redshift_cluster" "instance" {
   number_of_nodes     = 1
   skip_final_snapshot = true
   publicly_accessible = false
-  cluster_subnet_group_name = module.workshop-core.subnet_group_id
+  cluster_subnet_group_name = aws_redshift_subnet_group.workshop-public-subnet-group.id
   vpc_security_group_ids = [module.workshop-core.security_group_id]
 }
 

--- a/extensions/aws-s3/terraform/aws_s3_main.tf
+++ b/extensions/aws-s3/terraform/aws_s3_main.tf
@@ -4,7 +4,7 @@ resource "random_string" "s3_random_string" {
   special = false
   upper = false
   lower = true
-  number = false
+  numeric = false
 }
 
 data "template_file" "s3_bucket_name" {
@@ -13,13 +13,19 @@ data "template_file" "s3_bucket_name" {
 
 resource "aws_s3_bucket" "bucket" {
   bucket   = "tf-bucket-${data.template_file.s3_bucket_name.rendered}"
-  acl      = "private"
   force_destroy = true
+}
 
-  versioning {
-    enabled = false
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "bucket_versioning" {
+  bucket = aws_s3_bucket.bucket.id
+  versioning_configuration {
+    status = "Disabled"
   }
-
 }
 
 
@@ -98,7 +104,7 @@ resource "null_resource" "s3_provisioners" {
 
   provisioner "remote-exec" {
     inline = [
-      "cat /tmp/s3_bucket_info.txt >> ~/.workshop/docker/.env",
+      "cat /tmp/s3_bucket_info.txt >> .workshop/docker/.env",
       "rm /tmp/s3_bucket_info.txt"
     ]
 

--- a/extensions/azure-blob-storage/terraform/azure_storage_main.tf
+++ b/extensions/azure-blob-storage/terraform/azure_storage_main.tf
@@ -2,6 +2,7 @@
 locals {
   common_tags = {
     project  = "workshop-framework"
+    deployed_By = "Terraform"
   }
   extra_tags  = {
     workshop-name = "${var.name}"
@@ -37,9 +38,9 @@ resource "null_resource" "add_vars_azure_storage" {
 
   provisioner "remote-exec" {
     inline = [
-      "echo 'AZURE_STORAGE_ACCOUNT_NAME=${data.azurerm_storage_account.instance.name}' >> ~/.workshop/docker/.env",
-      "echo 'AZURE_STORAGE_ACCOUNT_KEY=${data.azurerm_storage_account.instance.primary_access_key}' >> ~/.workshop/docker/.env",
-      "echo 'AZURE_STORAGE_CONTAINER=${azurerm_storage_container.instance.name}' >> ~/.workshop/docker/.env"
+      "echo 'AZURE_STORAGE_ACCOUNT_NAME=${data.azurerm_storage_account.instance.name}' >> .workshop/docker/.env",
+      "echo 'AZURE_STORAGE_ACCOUNT_KEY=${data.azurerm_storage_account.instance.primary_access_key}' >> .workshop/docker/.env",
+      "echo 'AZURE_STORAGE_CONTAINER=${azurerm_storage_container.instance.name}' >> .workshop/docker/.env"
     ]
 
     connection {

--- a/extensions/azure-blob-storage/terraform/azure_storage_outputs.tf
+++ b/extensions/azure-blob-storage/terraform/azure_storage_outputs.tf
@@ -1,4 +1,5 @@
 output "storage_account_access_keys" {
   depends_on = [azurerm_storage_account.instance]
   value      = data.azurerm_storage_account.instance.*.primary_access_key
+  sensitive = true
 }

--- a/extensions/google-big-query/terraform/gbq_main.tf
+++ b/extensions/google-big-query/terraform/gbq_main.tf
@@ -52,9 +52,9 @@ resource "null_resource" "gbq_provisioners" {
   provisioner "remote-exec" {
     inline = [
       "sleep 180",
-      "echo 'GBQ_CREDENTIALS_PATH=/tmp/gbq_creds.json' >> ~/.workshop/docker/.env",
-      "echo 'GBQ_DATASET=${var.name}_dataset' >> ~/.workshop/docker/.env",
-      "echo 'GBQ_PROJECT=${var.gbq_project}' >> ~/.workshop/docker/.env",
+      "echo 'GBQ_CREDENTIALS_PATH=/tmp/gbq_creds.json' >> .workshop/docker/.env",
+      "echo 'GBQ_DATASET=${var.name}_dataset' >> .workshop/docker/.env",
+      "echo 'GBQ_PROJECT=${var.gbq_project}' >> .workshop/docker/.env",
       "docker cp /tmp/gbq_creds.json kafka-connect-ccloud:/tmp",
       "rm /tmp/gbq_creds.json"
     ]

--- a/extensions/google-cloud-storage/terraform/gcs_main.tf
+++ b/extensions/google-cloud-storage/terraform/gcs_main.tf
@@ -61,8 +61,8 @@ resource "null_resource" "vm_provisioners" {
   provisioner "remote-exec" {
     inline = [
       "sleep 180",
-      "echo 'GCS_BUCKET_NAME=${var.name}-gcssink-bucket' >> ~/.workshop/docker/.env",
-      "echo 'GCS_CREDENTIALS_PATH=/tmp/gcs_creds.json' >> ~/.workshop/docker/.env",
+      "echo 'GCS_BUCKET_NAME=${var.name}-gcssink-bucket' >> .workshop/docker/.env",
+      "echo 'GCS_CREDENTIALS_PATH=/tmp/gcs_creds.json' >> .workshop/docker/.env",
       "docker cp /tmp/gcs_creds.json kafka-connect-ccloud:/tmp",
       "rm /tmp/gcs_creds.json"
     ]

--- a/extensions/mongodbatlas/terraform/mongodbatlas_main.tf
+++ b/extensions/mongodbatlas/terraform/mongodbatlas_main.tf
@@ -61,8 +61,8 @@ resource "null_resource" "vm_provisioners_atlas" {
   provisioner "remote-exec" {
     inline = [
       "sleep 30",
-      "echo 'MONGODBATLAS_SRV_ADDRESS=${local.mongodbatlas_srv_address}' >> ~/.workshop/docker/.env",
-      "echo 'MONGODBATLAS_MONGO_URI=${data.mongodbatlas_cluster.confluent.mongo_uri}' >> ~/.workshop/docker/.env"
+      "echo 'MONGODBATLAS_SRV_ADDRESS=${local.mongodbatlas_srv_address}' >> .workshop/docker/.env",
+      "echo 'MONGODBATLAS_MONGO_URI=${data.mongodbatlas_cluster.confluent.mongo_uri}' >> .workshop/docker/.env"
     ]
 
     connection {
@@ -134,7 +134,7 @@ resource "null_resource" "vm_provisioners_atlas_realm_app" {
   provisioner "file" {
     content      = templatefile("${path.module}/add_realm_url_to_docs.tpl", { 
       mongodbatlas_realm_app_id   = self.triggers.realm_app_id
-      asciidoc_index_path  = "~/.workshop/docker/asciidoc/hybrid-cloud-workshop.html"
+      asciidoc_index_path  = ".workshop/docker/asciidoc/hybrid-cloud-workshop.html"
     })
     destination = "/tmp/add_realm_url_to_docs.sh"
 

--- a/workshop-example-aws.yaml
+++ b/workshop-example-aws.yaml
@@ -31,9 +31,15 @@ workshop:
     #ami: ami-0b9064170e32bde34
 
     # The workshop Confluent Cloud configuration
-    ccloud_bootstrap_servers: <CCloud Bootstrap Server>
+    # ccloud_bootstrap_servers: <CCloud Bootstrap Server>
     ccloud_api_key: <CCloud API Key>
     ccloud_api_secret: <CCloud API Secret>
+    ccloud_env_name: <CCloud Environment Name>
+    ccloud_cluster_name: <CCloud Cluster Name>
+    #ccloud_cluster_availability_type: SINGLE_ZONE
+    ccloud_cluster_availability_type: <CCloud Cluster Availability Type>
+    ccloud_sr_region: eu-central-1
+    ccloud_package_sg: ESSENTIALS
 
     # List of ccloud topics to pre-create
     ccloud_topics: sales_orders,sales_order_details,purchase_orders,purchase_order_details,customers,suppliers,products

--- a/workshop-example-azure.yaml
+++ b/workshop-example-azure.yaml
@@ -24,9 +24,15 @@ workshop:
     vm_disk_size: 100
 
     # The workshop Confluent Cloud configuration
-    ccloud_bootstrap_servers: <CCloud Bootstrap Server>
+    # ccloud_bootstrap_servers: <CCloud Bootstrap Server>
     ccloud_api_key: <CCloud API Key>
     ccloud_api_secret: <CCloud API Secret>
+    ccloud_env_name: <CCloud Environment Name>
+    ccloud_cluster_name: <CCloud Cluster Name>
+    #ccloud_cluster_availability_type: SINGLE_ZONE
+    ccloud_cluster_availability_type: <CCloud Cluster Availability Type>
+    ccloud_sr_region: westeurope
+    ccloud_package_sg: ESSENTIALS
 
     # List of ccloud topics to pre-create
     ccloud_topics: sales_orders,sales_order_details,purchase_orders,purchase_order_details,customers,suppliers,products
@@ -36,6 +42,10 @@ workshop:
     #Feedback Form url (Optional)
     #feedback_form_url: "<Feedback Form Url>"
 
+    #tags
+    owner_email: <Your email>
+    purpose: <Workshop name>
+    ref_link: <Workshop Git repo url>
   #
   # workshop extensions
   #


### PR DESCRIPTION
Adding Confluent Terraform Provider to automatically create Confluent Cloud components.
Updating GCP and Azure to make them work.
Updating extensions to make them work.
adding GCP and Azure credentials check before creating/destroying workshop.